### PR TITLE
Verify release is current by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ heroku verify-release ...
 
 ## `heroku verify-release [RELEASE]`
 
-Verify a successful release 
+Verify a successful release
 
 ```
 USAGE
@@ -43,6 +43,7 @@ ARGUMENTS
 
 OPTIONS
   --app=app          (required) app name
+  --ignore-current   Skip verifying the release is current
   --timeout=timeout  [default: 30000] how long should we poll for
 
 DESCRIPTION
@@ -50,5 +51,5 @@ DESCRIPTION
   Exits with a non zero exit code when the release failed
 ```
 
-_See code: [src/commands/verify-release.ts](https://github.com/envato/heroku-plugin/blob/v0.0.4/src/commands/verify-release.ts)_
+_See code: [src/commands/verify-release.ts](https://github.com/envato/heroku-plugin/blob/v1.0.0/src/commands/verify-release.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/heroku-plugin",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "author": "Glenn Baker @gbakernet",
   "bugs": "https://github.com/envato/heroku-plugin/issues",
   "devDependencies": {

--- a/src/commands/verify-release.ts
+++ b/src/commands/verify-release.ts
@@ -35,13 +35,17 @@ class VerifyRelease extends Command {
 
     if (releaseInfo.status === "succeeded") {
       this.log(`Release description: "${releaseInfo.description}"`);
-      this.log(
-        chalk.green(
-          `Verified succeeded ${
-            releaseInfo.current ? "(current)" : "(not current)"
-          }`
-        )
-      );
+      if (!flags["ignore-current"] && !releaseInfo.current) {
+        this.error(`Verification failed, release is not current`, { exit: 3 });
+      } else {
+        this.log(
+          chalk.green(
+            `Verification succeeded ${
+              releaseInfo.current ? "(current)" : "(not current)"
+            }`
+          )
+        );
+      }
     } else if (releaseInfo.status === "pending") {
       this.error(`Timed out waiting for heroku API`, { exit: 124 });
     } else {
@@ -68,7 +72,7 @@ class VerifyRelease extends Command {
   }
 }
 
-VerifyRelease.description = `Verify a successful release 
+VerifyRelease.description = `Verify a successful release
 ...
 Exits with a non zero exit code when the release failed
 `;
@@ -77,6 +81,10 @@ VerifyRelease.flags = {
   app: flags.string({
     required: true,
     description: "app name",
+  }),
+  "ignore-current": flags.boolean({
+    description: "Skip verifying the release is current",
+    default: false,
   }),
   timeout: flags.string({
     description: "how long should we poll for",


### PR DESCRIPTION
## Changes

* Verifies the release is current
* Increment major version 1.0.0

## Command

Verify a successful release

```
USAGE
  $ heroku verify-release [RELEASE]

ARGUMENTS
  RELEASE  release number (default: latest)

OPTIONS
  --app=app          (required) app name
  --ignore-current   Skip verifying the release is current
  --timeout=timeout  [default: 30000] how long should we poll for

DESCRIPTION
  ...
  Exits with a non zero exit code when the release failed
```