### PR TITLE
Pin @oclif/config to version 1.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/heroku-plugin",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -253,18 +253,29 @@
       }
     },
     "@oclif/config": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
-      "integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.1.tgz",
+      "integrity": "sha512-UqV5qsN2np96TNlJspSNlRl7CpFmxYSrB0iLe3XV9NDkbFEE5prGP++h6w6xOR/FL3QV7BoqrbwGuJdJdFbidw==",
       "requires": {
         "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.0",
+        "@oclif/parser": "^3.8.6",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
         "tslib": "^2.0.0"
       },
       "dependencies": {
+        "@oclif/parser": {
+          "version": "3.8.6",
+          "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
+          "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+          "requires": {
+            "@oclif/errors": "^1.2.2",
+            "@oclif/linewrap": "^1.0.0",
+            "chalk": "^4.1.0",
+            "tslib": "^2.0.0"
+          }
+        },
         "globby": {
           "version": "11.0.4",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -279,9 +290,9 @@
           }
         },
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
         },
         "tslib": {
           "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/heroku-plugin",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Glenn Baker @gbakernet",
   "bugs": "https://github.com/envato/heroku-plugin/issues",
   "devDependencies": {
@@ -53,7 +53,7 @@
     "@heroku-cli/command": "^8.5.0",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1.8.0",
-    "@oclif/config": "^1.17.0",
+    "@oclif/config": "1.17.1",
     "chalk": "^4.1.2",
     "tslib": "^1.14.1"
   }


### PR DESCRIPTION
Unblocking deployment pipelines failing on 1.18.0. Pinning 1.17.1

```
module: @oclif/config@1.18.0
--
  | task: loadPlugins
  | plugin: heroku
  | root: /usr/local/share/.config/yarn/global/node_modules/heroku
  | See more details with DEBUG=*
  | (node:21) Error Plugin: heroku: could not find package.json with {
  | type: 'core',
  | root: '/usr/local/share/.config/yarn/global/node_modules/heroku',
  | name: '@heroku-cli/plugin-certs'
  | }
```